### PR TITLE
Make the host port used by loki and grafana configurable

### DIFF
--- a/testnets/global_network/docker-compose.yaml
+++ b/testnets/global_network/docker-compose.yaml
@@ -826,7 +826,7 @@ services:
     restart: unless-stopped
     command: -config.file=/etc/loki/local-config.yaml
     ports:
-      - "3100:3100"
+      - "${LOKI_HOST:-3100}:3100"
     volumes:
       - loki:/loki
     networks:
@@ -842,7 +842,7 @@ services:
     hostname: grafana.example
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "${GRAFANA_HOST:-3000}:3000"
     volumes:
       - grafana:/var/lib/grafana
       - ../../grafana/provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
The host port used by loki and grafana may clash with other services running on the host.
This makes it possible to set the ip and port using the environment variables LOKI_HOST and GRAFANA_HOST.