### PR TITLE
Harmonize testnet parameters

### DIFF
--- a/testnets/global_network/testnet.yaml
+++ b/testnets/global_network/testnet.yaml
@@ -14,11 +14,12 @@ protocolConsts:
   k: 432
 
 --- # Optional Shelley Genesis Overide
-slotLength: 0.2
-epochLength: 86400
-securityParam: 432
+slotLength: 1
+epochLength: 17280
+securityParam: 90
 maxLovelaceSupply: 45000000000000000
 protocolParams:
+  maxBlockBodySize: 90112
   decentralisationParam: 0
   protocolVersion:
     major: 10

--- a/testnets/simple_mixed_consensus/testnet.yaml
+++ b/testnets/simple_mixed_consensus/testnet.yaml
@@ -14,10 +14,12 @@ protocolConsts:
   k: 432
 
 --- # Optional Shelley Genesis Overide
-epochLength: 86400
-securityParam: 432
+slotLength: 1
+epochLength: 17280
+securityParam: 90
 maxLovelaceSupply: 45000000000000000
 protocolParams:
+  maxBlockBodySize: 90112
   decentralisationParam: 0
   protocolVersion:
     major: 10

--- a/testnets/simple_network_binary/testnet.yaml
+++ b/testnets/simple_network_binary/testnet.yaml
@@ -14,10 +14,12 @@ protocolConsts:
   k: 432
 
 --- # Optional Shelley Genesis Overide
-epochLength: 86400
-securityParam: 432
+slotLength: 1
+epochLength: 17280
+securityParam: 90
 maxLovelaceSupply: 45000000000000000
 protocolParams:
+  maxBlockBodySize: 90112
   decentralisationParam: 0
   protocolVersion:
     major: 10

--- a/testnets/simple_network_source/testnet.yaml
+++ b/testnets/simple_network_source/testnet.yaml
@@ -14,10 +14,12 @@ protocolConsts:
   k: 432
 
 --- # Optional Shelley Genesis Overide
-epochLength: 86400
-securityParam: 432
+slotLength: 1
+epochLength: 17280
+securityParam: 90
 maxLovelaceSupply: 45000000000000000
 protocolParams:
+  maxBlockBodySize: 90112
   decentralisationParam: 0
   protocolVersion:
     major: 10


### PR DESCRIPTION
Set maxBlockBodySize to 90112 (as mainnet)
Increase slotLength to 1
Decrease epochLength to 17280
Decrease securityParam to 90