### PR TITLE
Prefer dummy devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,13 @@ export DOCKER_DEFAULT_PLATFORM?=linux/amd64
 
 # Determine and set the parent network interface
 HOST_INTERFACE_SETUP = \
-	if [ -z "$${HOST_INTERFACE+x}" ]; then \
-		HOST_INTERFACE=$$(ip -br link show | awk '$$1 !~ /^lo$$/ && $$1 !~ /^vir/ && $$1 !~ /^wl/ && $$1 !~ /@/ {print $$1; exit}') && \
-		[ -n "$$HOST_INTERFACE" ] || { echo "No physical interface found"; exit 1; }; \
-	fi && \
-	export HOST_INTERFACE && \
-	echo "Using HOST_INTERFACE=\"$$HOST_INTERFACE"\"
+    if [ -z "$${HOST_INTERFACE+x}" ]; then \
+        HOST_INTERFACE=$$(ip -br link show | awk '$$1 ~ /^dummy[0-9]*$$/ {print $$1; exit}') ; \
+        [ -n "$$HOST_INTERFACE" ] || HOST_INTERFACE=$$(ip -br link show | awk '$$1 !~ /^lo$$|^vir|^wl/ && $$1 !~ /@/ {print $$1; exit}'); \
+        [ -n "$$HOST_INTERFACE" ] || { echo "No physical interface found"; exit 1; }; \
+    fi && \
+    export HOST_INTERFACE && \
+    echo "Using HOST_INTERFACE=\"$$HOST_INTERFACE\""
 
 help:
 	@echo

--- a/SETUP.md
+++ b/SETUP.md
@@ -86,3 +86,23 @@ Please install the dependencies below. All commands are compatible with Debian 1
   ```
 
   Relog to have the group change take affect.
+
+### Dummy Interface
+
+The Docker setup for advanced test networks uses a macvlan driver in bridge mode, requiring assignment of a parent network interface. You can explicitly specify this parent interface using the `HOST_INTERFACE` environment variable. When unset, the Makefile automatically selects an available interface, prioritizing dummy interfaces over physical ones.
+
+The primary advantage of selecting a dummy interface is network isolation: Unlike physical interfaces (e.g., eth0), a dummy device:
+* Prevents MAC address leakage
+* Avoids potential conflicts with other devices on your LAN.
+
+This isolation ensures test network activities don't inadvertently impact or become visible to external networks.
+
+To create a dummy device run the following commands:
+
+  ```
+  sudo modprobe dummy
+  sudo ip link add dummy0 type dummy
+  sudo ip link set dummy0 up
+  ```
+
+Check your linux dist for instructions on how to have the dummy device be created at boot.


### PR DESCRIPTION
Update the HOST_INTERFACE detection to prefer dummy devices over other devices.
Add section to SETUP.md explaining why dummy devices should be used and how to create them.