### PR TITLE
More robust yaci-store start.

### DIFF
--- a/scripts/wait_on_tip.sh
+++ b/scripts/wait_on_tip.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# Wait until the specific peer's tip is at least the specified
+# block number.
+#
+ 
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <host> <port> <target_block_number>" >&2
+    exit 1
+fi
+
+HOST="$1"
+PORT="$2"
+TARGET_BLOCK="$3"
+
+echo -n "Waiting for tip >= ${TARGET_BLOCK} on ${HOST}:${PORT}..."
+
+while true; do
+    output=$(cardano-cli ping -h "${HOST}" -p "${PORT}" -m 42 -j -q -t 2>&1)
+    ping_status=$?
+
+    if [ ${ping_status} -eq 0 ]; then
+        blockNo=$(echo "$output" | jq -r '.tip[0].blockNo' 2>/dev/null)
+        jq_status=$?
+
+        if [ ${jq_status} -eq 0 ] && [ -n "${blockNo}" ] && [[ "${blockNo}" =~ ^[0-9]+$ ]]; then
+            if [ "${blockNo}" -ge "${TARGET_BLOCK}" ]; then
+                echo " tip at ${blockNo}."
+                exit 0
+            fi
+        fi
+    fi
+    echo -n "."
+    sleep 5
+done

--- a/yaci-store/Dockerfile.binary
+++ b/yaci-store/Dockerfile.binary
@@ -8,6 +8,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 FROM docker.io/debian:stable-20250630-slim AS build
 
+ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-10.4.1}"
 ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.9.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 ARG YACI_STORE_VERSION="${YACI_STORE_VERSION:-2.0.0-beta3}"
@@ -21,6 +22,21 @@ RUN apt update && \
     ca-certificates \
     curl \
     unzip
+
+# cardano-cli
+RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-node
+
+RUN curl --proto '=https' --tlsv1.2 \
+        --location https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VERSION}/cardano-node-${CARDANO_NODE_VERSION}-linux.tar.gz \
+        --output /usr/local/src/cardano-node/cardano-node-${CARDANO_NODE_VERSION}-linux.tar.gz
+
+RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-node/${CARDANO_NODE_VERSION}
+
+RUN tar --extract --gzip --file=/usr/local/src/cardano-node/cardano-node-${CARDANO_NODE_VERSION}-linux.tar.gz --directory=/usr/local/src/cardano-node/${CARDANO_NODE_VERSION}
+
+RUN chmod 0755 /usr/local/src/cardano-node/${CARDANO_NODE_VERSION}/bin/cardano-cli
+
+RUN ln -s /usr/local/src/cardano-node/${CARDANO_NODE_VERSION}/bin/cardano-cli /usr/local/bin/cardano-cli
 
 # yaci-store
 
@@ -103,6 +119,7 @@ RUN apt update && \
         telnet \
         vim
 
+COPY --from=build --chown=root:root /usr/local/bin/cardano-cli /usr/local/bin/cardano-cli
 COPY --from=build --chown=root:root /usr/local/bin/node_exporter /usr/local/bin/node_exporter
 COPY --from=build --chown=root:root /usr/local/bin/process_exporter /usr/local/bin/process_exporter
 
@@ -127,6 +144,9 @@ RUN chmod 0755 /cmd.sh
 
 COPY scripts/node_routes.sh /
 RUN chmod 0755 /node_routes.sh
+
+COPY scripts/wait_on_tip.sh /
+RUN chmod 0755 /wait_on_tip.sh
 
 USER cardano
 

--- a/yaci-store/cmd.sh
+++ b/yaci-store/cmd.sh
@@ -59,6 +59,9 @@ main () {
     start_node_exporter &
     start_process_exporter &
 
+    # Yaci-store can't handle early forks.
+    # Wait until c1's tip is at least on block number 3.
+    /wait_on_tip.sh c1.example 3001 3
     cd /opt/yaci
     SPRING_PROFILES_ACTIVE=ledger-state ./yaci-store
 }


### PR DESCRIPTION
Yaci-store can't handle early forks so by waiting until c1 has seen at least 3 blocks we reduce the risk of yaci-store failing to apply the first few blocks.