### PR TITLE
Update PostgreSQL package name

### DIFF
--- a/blockfrost/Dockerfile
+++ b/blockfrost/Dockerfile
@@ -106,7 +106,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/cardano-db-sync/Dockerfile.binary
+++ b/cardano-db-sync/Dockerfile.binary
@@ -99,7 +99,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/cardano-node/Dockerfile.binary
+++ b/cardano-node/Dockerfile.binary
@@ -107,7 +107,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/cardano-node/Dockerfile.source
+++ b/cardano-node/Dockerfile.source
@@ -243,7 +243,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -28,8 +28,8 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-15 \
-        postgresql-client-15 \
+        postgresql \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -77,7 +77,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \

--- a/yaci-store/Dockerfile.binary
+++ b/yaci-store/Dockerfile.binary
@@ -113,7 +113,7 @@ RUN apt update && \
         netbase \
         netcat-openbsd \
         openssl \
-        postgresql-client-15 \
+        postgresql-client \
         procps \
         tcpdump \
         telnet \


### PR DESCRIPTION
- Remove PostgreSQL version from package name (Debian 13 has been released and Debian 12 is now oldstable)