### PR TITLE
Gateway + other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,11 @@ up-all: TESTNET ## Start testnet with optional containers (Blockfrost, TX Genera
 
 down: TESTNET ## Stop testnet
 	@cd testnets/${testnet} && \
-	docker compose --env-file .env.tmp --profile core --profile optional --profile privaterelays down --volumes --timeout 5 && \
+	$(HOST_INTERFACE_SETUP) && \
+	docker compose --env-file .env.tmp --profile core --profile optional --profile privaterelays down --volumes --remove-orphans --timeout 5 && \
+	for vlan in $$(yq '.networks[].driver_opts.parent | select(. != null)' docker-compose.yaml | grep -oE '[0-9]+$$'); do \
+		ip link show "$${HOST_INTERFACE}.$${vlan}" >/dev/null 2>&1 && ip link delete "$${HOST_INTERFACE}.$${vlan}" || true ; \
+	done && \
 	rm -f .env.tmp
 
 query: TESTNET ## Query tip of all pools

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ up-all: TESTNET ## Start testnet with optional containers (Blockfrost, TX Genera
 
 down: TESTNET ## Stop testnet
 	@cd testnets/${testnet} && \
-	docker compose --env-file .env.tmp --profile core --profile optional --profile privaterelays down --volumes --timeout 1 && \
+	docker compose --env-file .env.tmp --profile core --profile optional --profile privaterelays down --volumes --timeout 5 && \
 	rm -f .env.tmp
 
 query: TESTNET ## Query tip of all pools

--- a/cardano-node/cmd.sh
+++ b/cardano-node/cmd.sh
@@ -526,6 +526,13 @@ main() {
 
         cp -r /opt/synth/db "${DATA_PATH}"
         cp /opt/synth/start_time.unix_epoch "${DATA_PATH}"
+
+        # Overwrite baked-in genesis with the synth copy so all node variants
+        # (e.g. A/B test) use a single authoritative source of truth.
+        if [ -d /opt/synth/pools ]; then
+            cp /opt/synth/pools/${POOL_ID}/configs/shelley-genesis.json "${SHELLEY_GENESIS_JSON}"
+            cp /opt/synth/pools/${POOL_ID}/configs/byron-genesis.json "${BYRON_GENESIS_JSON}"
+        fi
     fi
 
     set_start_time

--- a/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
+++ b/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Have globa_network_2c use the standard gateway/scripts/gw_routes.sh script
+

--- a/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
+++ b/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Bump timeout for bringing down containers from 1s to 5s.
+
 ### Fixed
 
 - Have globa_network_2c use the standard gateway/scripts/gw_routes.sh script

--- a/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
+++ b/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
@@ -5,4 +5,5 @@
 ### Fixed
 
 - Have globa_network_2c use the standard gateway/scripts/gw_routes.sh script
+- down target, clean up any orphan containers and interfaces we created
 

--- a/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
+++ b/changelog.d/20260415_133341_karl.fb.knutsson_gw_fix.md
@@ -6,4 +6,5 @@
 
 - Have globa_network_2c use the standard gateway/scripts/gw_routes.sh script
 - down target, clean up any orphan containers and interfaces we created
+- Copy genesis files from synth to prevent missmatch between different cardano-node versions.
 

--- a/db-synthesizer/cmd.sh
+++ b/db-synthesizer/cmd.sh
@@ -109,10 +109,15 @@ generate_pre_epochs() {
 
 if [ ! -f "${DATA_PATH}/start_time.unix_epoch" ]; then
     set_start_time
-    
+
     if [ -n "${PRE_EPOCHS}" ] && [ "${PRE_EPOCHS}" -gt 0 ] 2>/dev/null; then
         generate_pre_epochs
     fi
 
     echo "${SYSTEM_START_UNIX_ADJUSTED}" >"${DATA_PATH}/start_time.unix_epoch"
 fi
+
+# Publish pool configs (including genesis files) to the synth volume so all
+# node variants use a single authoritative genesis regardless of when their
+# images were built.
+cp -r /opt/cardano-node/pools "${DATA_PATH}/pools"

--- a/gateway/scripts/gw_routes.sh
+++ b/gateway/scripts/gw_routes.sh
@@ -12,80 +12,104 @@ case ${GATEWAY_ID} in
     "nagw")
         echo "starting North America Gateway"
 
-        echo "North America <-> Europe"
-        GW="172.16.2.12"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 50ms 3ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.2\.'; then
+            echo "North America <-> Europe"
+            GW="172.16.2.12"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 50ms 3ms loss 0.5%
+        fi
 
-        echo "North America <-> Asia"
-        GW="172.16.6.13"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 100ms 6ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.6\.'; then
+            echo "North America <-> Asia"
+            GW="172.16.6.13"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 100ms 6ms loss 0.5%
+        fi
 
-        echo "North America <-> Admin"
-        GW="172.16.10.14"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.10\.'; then
+            echo "North America <-> Admin"
+            GW="172.16.10.14"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
         ;;
     "eugw")
         echo "starting Europe Gateway"
 
-        echo "Europe <-> North America"
-        GW="172.16.2.11"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 50ms 3ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.2\.'; then
+            echo "Europe <-> North America"
+            GW="172.16.2.11"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 50ms 3ms loss 0.5%
+        fi
 
-        echo "Europe <-> Asia"
-        GW="172.16.5.13"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 75ms 6ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.5\.'; then
+            echo "Europe <-> Asia"
+            GW="172.16.5.13"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 75ms 6ms loss 0.5%
+        fi
 
-        echo "Europe <-> Admin"
-        GW="172.16.9.14"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.9\.'; then
+            echo "Europe <-> Admin"
+            GW="172.16.9.14"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
         ;;
     "asgw")
         echo "starting Asia Gateway"
 
-        echo "Asia <-> Europe"
-        GW="172.16.5.12"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 75ms 6ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.5\.'; then
+            echo "Asia <-> Europe"
+            GW="172.16.5.12"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 75ms 6ms loss 0.5%
+        fi
 
-        echo "Asia <-> North America"
-        GW="172.16.6.11"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
-        tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 100ms 6ms loss 0.5%
+        if ip route show scope link | grep -q '^172\.16\.6\.'; then
+            echo "Asia <-> North America"
+            GW="172.16.6.11"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
+            tc qdisc replace dev "${INTERFACE}" root netem rate 1000mbit delay 100ms 6ms loss 0.5%
+        fi
 
-        echo "Asia <-> Admin"
-        GW="172.16.8.14"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.8\.'; then
+            echo "Asia <-> Admin"
+            GW="172.16.8.14"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.7.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
         ;;
     "adgw")
         echo "starting Admin Gateway"
 
-        echo "Admin <-> Europe"
-        GW="172.16.9.12"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.9\.'; then
+            echo "Admin <-> Europe"
+            GW="172.16.9.12"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.3.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
 
-        echo "Admin <-> North America"
-        GW="172.16.10.11"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.10\.'; then
+            echo "Admin <-> North America"
+            GW="172.16.10.11"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.1.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
 
-        echo "Admin <-> Asia"
-        GW="172.16.8.13"
-        INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
-        ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
+        if ip route show scope link | grep -q '^172\.16\.8\.'; then
+            echo "Admin <-> Asia"
+            GW="172.16.8.13"
+            INTERFACE=$(ip route get "${GW}" | awk '{print $3}')
+            ip route add 172.16.4.0/24 via "${GW}" dev "${INTERFACE}"
+        fi
         ;;
     *)
         echo "unknown Gateway"

--- a/testnets/global_network_2c/docker-compose.yaml
+++ b/testnets/global_network_2c/docker-compose.yaml
@@ -115,8 +115,6 @@ x-base_gw: &base_gw
     - NET_RAW
   sysctls:
     net.ipv4.ip_forward: "1"
-  volumes:
-    - ./gateway/gw_routes.sh:/opt/scripts/gw_routes.sh:ro
 
 x-pool_pair_a_cpu: &pool_pair_a_cpu
   cpuset: "${POOL_PAIR_A_CPUSET:-2-4}"


### PR DESCRIPTION
- Have globa_network_2c use the standard gateway/scripts/gw_routes.sh script
- down target, clean up any orphan containers and interfaces we created
- Copy genesis files from synth to prevent missmatch between different cardano-node versions.
