### PR TITLE
Version Update

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -23,7 +23,7 @@ Please install the dependencies below. All commands are compatible with Debian 1
 
   ```
   curl --proto '=https' --tlsv1.2 \
-      --location https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64.tar.gz \
+      --location https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64.tar.gz \
       --output /tmp/yq_linux_amd64.tar.gz
   ```
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -6,20 +6,20 @@ This list outlines all software versions used in the Cardano Ignite project.
 |---                  |---           |---                                                                                         |
 |Amaru                |Source        |[1702069](https://github.com/pragma-org/amaru/commit/17020694ec00b39668dd0d9e87902f94e99590fa) |
 |Blackbox Exporter    |Image         |[v0.28.0](https://hub.docker.com/layers/prom/blackbox-exporter/v0.28.0)                     |
-|Blockfrost           |Binary        |[v6.2.0](https://github.com/blockfrost/blockfrost-backend-ryo/releases/tag/v6.2.0)          |
-|Cardano CLI          |Binary/Source |[10.11.1.0](https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-10.11.1.0) |
+|Blockfrost           |Binary        |[v6.4.0](https://github.com/blockfrost/blockfrost-backend-ryo/releases/tag/v6.4.0)          |
+|Cardano CLI          |Binary/Source |[10.15.1.0](https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-10.15.1.0) |
 |Cardano DB Sync      |Binary        |[13.6.0.4](https://github.com/IntersectMBO/cardano-db-sync/releases/tag/13.6.0.4)           |
 |Cardano Node         |Binary/Source |[10.5.1](https://github.com/IntersectMBO/cardano-node/releases/tag/10.5.1), [10.5.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.5.4), [10.6.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.4), [10.7.1](https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1) |
-|Cardano TX Generator |Source        |[10.5.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.5.4)                  |
-|CoreDNS              |Image         |[1.14.1](https://hub.docker.com/layers/coredns/coredns/1.14.1)                              |
-|Debian               |Image         |[stable-20260223-slim](https://hub.docker.com/layers/library/debian/stable-slim)            |
-|Grafana              |Image         |[12.4.0](https://hub.docker.com/layers/grafana/grafana/12.4.0)                              |
-|Jaeger               |Image         |[2.15.1](https://hub.docker.com/layers/jaegertracing/jaeger/2.15.1)                         |
-|Loki                 |Image         |[3.6.7](https://hub.docker.com/layers/grafana/loki/3.6.7)                                   |
-|Node Exporter        |Binary        |[v1.10.2](https://github.com/prometheus/node_exporter/releases/tag/v1.10.2)                 |
+|Cardano TX Generator |Source        |[10.6.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.4)                  |
+|CoreDNS              |Image         |[1.14.3](https://hub.docker.com/layers/coredns/coredns/1.14.3)                              |
+|Debian               |Image         |[stable-20260421-slim](https://hub.docker.com/layers/library/debian/stable-slim)            |
+|Grafana              |Image         |[13.0.1](https://hub.docker.com/layers/grafana/grafana/13.0.1)                              |
+|Jaeger               |Image         |[2.17.0](https://hub.docker.com/layers/jaegertracing/jaeger/2.17.0)                         |
+|Loki                 |Image         |[3.7.1](https://hub.docker.com/layers/grafana/loki/3.7.1)                                   |
+|Node Exporter        |Binary        |[v1.11.1](https://github.com/prometheus/node_exporter/releases/tag/v1.11.1)                 |
 |PostgreSQL           |Package       |[17.9](https://www.postgresql.org/docs/release/17.9)                                        |
 |Process Exporter     |Binary        |[v0.8.7](https://github.com/ncabatoff/process-exporter/releases/tag/v0.8.7)                 |
-|Prometheus           |Image         |[v3.10.0](https://hub.docker.com/layers/prom/prometheus/v3.10.0)                            |
+|Prometheus           |Image         |[v3.11.2](https://hub.docker.com/layers/prom/prometheus/v3.11.2)                            |
 |Yaci Store           |Image         |[v2.0.0](https://github.com/bloxbean/yaci-store/releases/tag/v2.0.0)                        |
-|uv                   |Binary        |[0.10.8](https://github.com/astral-sh/uv/releases/tag/0.10.8)                               |
-|yq                   |Binary        |[v4.52.4](https://github.com/mikefarah/yq/releases/tag/v4.52.4)                             |
+|uv                   |Binary        |[0.11.7](https://github.com/astral-sh/uv/releases/tag/0.11.7)                               |
+|yq                   |Binary        |[v4.53.2](https://github.com/mikefarah/yq/releases/tag/v4.53.2)                             |

--- a/amaru/Dockerfile.source
+++ b/amaru/Dockerfile.source
@@ -5,7 +5,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 FROM ${HASKELL_BUILDER_IMAGE} AS build
 
-ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.10.2}"
+ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 RUN apt-get update && \
@@ -123,7 +123,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 # Set time zone
 ENV TZ="UTC"

--- a/amaru/cmd.sh
+++ b/amaru/cmd.sh
@@ -216,7 +216,7 @@ generate_amaru_snapshots() {
         echo "Error: Could not determine latest snapshot" >&2
         return 1
     fi
-    
+
     echo "Snapshot processing completed successfully!"
 
     mkdir -p ${BASE_DIR}/${NETWORK}/headers

--- a/blockfrost/Dockerfile
+++ b/blockfrost/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
-ARG BLOCKFROST_BACKEND_RYO="${BLOCKFROST_BACKEND_RYO:-6.2.0}"
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.11.1.0}"
+ARG BLOCKFROST_BACKEND_RYO="${BLOCKFROST_BACKEND_RYO:-6.4.0}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
 ARG NODEJS_MAJOR_VERSION="${NODEJS_MAJOR_VERSION:-24}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
@@ -88,7 +88,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/cardano-db-sync/Dockerfile.binary
+++ b/cardano-db-sync/Dockerfile.binary
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.11.1.0}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
 ARG CARDANO_DB_SYNC_VERSION="${CARDANO_DB_SYNC_VERSION:-13.6.0.4}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
@@ -78,7 +78,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket" \
     PGPASSFILE="/opt/cardano-db-sync/config/pgpass"

--- a/cardano-node/Dockerfile.binary
+++ b/cardano-node/Dockerfile.binary
@@ -4,10 +4,10 @@ ARG TESTNET_BUILDER_IMAGE=scratch
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
 ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-10.5.4}"
-ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.10.2}"
+ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 ENV TZ="UTC"
@@ -85,7 +85,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/cardano-node/Dockerfile.source
+++ b/cardano-node/Dockerfile.source
@@ -7,7 +7,7 @@ ARG HASKELL_BUILDER_IMAGE=scratch
 
 FROM ${HASKELL_BUILDER_IMAGE} AS build
 
-ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.10.2}"
+ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 # NOTE:
@@ -36,7 +36,7 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 # cardano-cli
 
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.11.1.0}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
 
 WORKDIR /usr/local/src
 RUN git clone --depth 1 --branch master https://github.com/IntersectMBO/cardano-cli.git
@@ -132,7 +132,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/changelog.d/20260423_123415_l_version_update_20260423.md
+++ b/changelog.d/20260423_123415_l_version_update_20260423.md
@@ -1,0 +1,13 @@
+### Updated
+
+- Update Blockfrost from 6.2.0 to 6.4.0
+- Update Cardano TX Generator from 10.5.4 to 10.6.4
+- Update Cardano-CLI from 10.11.1.0 to 10.15.1.0
+- Update CoreDNS from 1.14.1 to 1.14.3
+- Update Debian from stable-20260223-slim to stable-20260421-slim
+- Update Grafana from 12.4.0 to 13.0.1
+- Update Jaeger from 2.15.1 to 2.17.0
+- Update Loki from 3.6.7 to 3.7.1
+- Update Prometheus from 3.10.0 to 3.11.2
+- Update uv from 0.10.8 to 0.11.7
+- Update ya from 4.52.4 to 4.53.2

--- a/db-synthesizer/Dockerfile
+++ b/db-synthesizer/Dockerfile
@@ -37,7 +37,7 @@ RUN strip --strip-unneeded /usr/local/bin/db-synthesizer
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
-ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.10.2}"
+ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
@@ -36,7 +36,7 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \

--- a/haskell-builder/Dockerfile
+++ b/haskell-builder/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------------------------------------
 #  Shared build environment for Cardano binaries
 # -------------------------------------------------
-ARG BASE_IMAGE=docker.io/debian:stable-20260223-slim
+ARG BASE_IMAGE=docker.io/debian:stable-20260421-slim
 FROM ${BASE_IMAGE} AS haskell-builder
 
 # ── Common ARGs (keep the defaults from the originals) ──

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 

--- a/scripts/wait_on_tip.sh
+++ b/scripts/wait_on_tip.sh
@@ -4,7 +4,7 @@
 # Wait until the specific peer's tip is at least the specified
 # block number.
 #
- 
+
 if [ $# -ne 3 ]; then
     echo "Usage: $0 <host> <port> <target_block_number>" >&2
     exit 1

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
-ARG CARDANO_CLI_VERSION="10.11.1.0"
+ARG CARDANO_CLI_VERSION="10.15.1.0"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 ENV TZ="UTC"
@@ -56,7 +56,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ARG GRAPHNODES
 

--- a/testnet-generation-tool/Dockerfile
+++ b/testnet-generation-tool/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260223-slim AS testnet_builder
+FROM docker.io/debian:stable-20260421-slim AS testnet_builder
 
-ARG UV_VERSION="${UV_VERSION:-0.10.8}"
+ARG UV_VERSION="${UV_VERSION:-0.11.7}"
 ARG TESTNET_GENERATION_TOOL_VERSION="v0.1.0"
 
 ENV TZ="UTC"

--- a/testnets/global_network/docker-compose.yaml
+++ b/testnets/global_network/docker-compose.yaml
@@ -763,7 +763,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -930,7 +930,7 @@ services:
     profiles: [build, optional, mgmt]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -978,7 +978,7 @@ services:
     profiles: [build, core, mgmt]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -996,7 +996,7 @@ services:
     profiles: [build, core, mgmt]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/global_network_2c/docker-compose.yaml
+++ b/testnets/global_network_2c/docker-compose.yaml
@@ -574,7 +574,7 @@ services:
     profiles: [build, core, mgmt, gateways]
 
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -723,7 +723,7 @@ services:
 
   prometheus:
     <<: *mgmt_cpu
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -769,7 +769,7 @@ services:
 
   loki:
     <<: *mgmt_cpu
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -788,7 +788,7 @@ services:
 
   grafana:
     <<: *mgmt_cpu
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/global_network_mixed_nodes/docker-compose.yaml
+++ b/testnets/global_network_mixed_nodes/docker-compose.yaml
@@ -752,7 +752,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -988,7 +988,7 @@ services:
     profiles: [build, optional, mgmt]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -1036,7 +1036,7 @@ services:
     profiles: [build, core, mgmt]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -1054,7 +1054,7 @@ services:
     profiles: [build, core, mgmt]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped
@@ -1075,7 +1075,7 @@ services:
     profiles: [build, core, mgmt]
 
   jaeger:
-    image: jaegertracing/jaeger:2.15.1
+    image: jaegertracing/jaeger:2.17.0
     container_name: jaeger
     hostname: jaeger.example
     restart: unless-stopped

--- a/testnets/simple_mixed_consensus/docker-compose.yaml
+++ b/testnets/simple_mixed_consensus/docker-compose.yaml
@@ -197,7 +197,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -313,7 +313,7 @@ services:
     profiles: [optional]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -339,7 +339,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -351,7 +351,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/simple_mixed_nodes_source/docker-compose.yaml
+++ b/testnets/simple_mixed_nodes_source/docker-compose.yaml
@@ -131,7 +131,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -246,7 +246,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -272,7 +272,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -284,7 +284,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped
@@ -299,7 +299,7 @@ services:
     profiles: [build, core]
 
   jaeger:
-    image: jaegertracing/jaeger:2.15.1
+    image: jaegertracing/jaeger:2.17.0
     container_name: jaeger
     hostname: jaeger.example
     restart: unless-stopped

--- a/testnets/simple_network_binary/docker-compose.yaml
+++ b/testnets/simple_network_binary/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -174,7 +174,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -200,7 +200,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -212,7 +212,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/simple_network_source/docker-compose.yaml
+++ b/testnets/simple_network_source/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -194,7 +194,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -220,7 +220,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -232,7 +232,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/single_pool_binary/docker-compose.yaml
+++ b/testnets/single_pool_binary/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
 
   # DNS Server
   ns:
-    image: coredns/coredns:1.14.1
+    image: coredns/coredns:1.14.3
     container_name: ns
     hostname: ns.example
     restart: unless-stopped
@@ -149,7 +149,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.2
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -175,7 +175,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.6.7
+    image: grafana/loki:3.7.1
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -187,7 +187,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:12.4.0
+    image: grafana/grafana:13.0.1
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/yaci-store/Dockerfile.binary
+++ b/yaci-store/Dockerfile.binary
@@ -6,10 +6,10 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS build
+FROM docker.io/debian:stable-20260421-slim AS build
 
 ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-10.5.4}"
-ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.10.2}"
+ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 ARG YACI_STORE_VERSION="${YACI_STORE_VERSION:-2.0.0}"
 
@@ -94,7 +94,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260223-slim AS main
+FROM docker.io/debian:stable-20260421-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \


### PR DESCRIPTION
Update Blockfrost from 6.2.0 to 6.4.0
Update Cardano TX Generator from 10.5.4 to 10.6.4
Update Cardano-CLI from 10.11.1.0 to 10.15.1.0
Update CoreDNS from 1.14.1 to 1.14.3
Update Debian from stable-20260223-slim to stable-20260421-slim
Update Grafana from 12.4.0 to 13.0.1
Update Jaeger from 2.15.1 to 2.17.0
Update Loki from 3.6.7 to 3.7.1
Update Prometheus from 3.10.0 to 3.11.2
Update uv from 0.10.8 to 0.11.7
Update ya from 4.52.4 to 4.53.2