### PR TITLE
Version Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install --no-install-recommends -y ca-certificates curl iproute2 make tar
-          curl --proto '=https' --tlsv1.2 --location https://github.com/mikefarah/yq/releases/download/v4.47.2/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+          curl --proto '=https' --tlsv1.3 --location https://github.com/mikefarah/yq/releases/download/v4.47.2/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
           sudo tar --extract --gzip --file=/tmp/yq_linux_amd64.tar.gz --directory=/usr/local/bin ./yq_linux_amd64 --transform='s|yq_linux_amd64|yq|' --no-same-owner
           make cibuild testnet=simple_network_binary
           make up testnet=simple_network_binary

--- a/SETUP.md
+++ b/SETUP.md
@@ -22,7 +22,7 @@ Please install the dependencies below. All commands are compatible with Debian 1
 - Download `yq` archive
 
   ```
-  curl --proto '=https' --tlsv1.2 \
+  curl --proto '=https' --tlsv1.3 \
       --location https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64.tar.gz \
       --output /tmp/yq_linux_amd64.tar.gz
   ```

--- a/VERSION.md
+++ b/VERSION.md
@@ -6,20 +6,20 @@ This list outlines all software versions used in the Cardano Ignite project.
 |---                  |---           |---                                                                                         |
 |Amaru                |Source        |[1702069](https://github.com/pragma-org/amaru/commit/17020694ec00b39668dd0d9e87902f94e99590fa) |
 |Blackbox Exporter    |Image         |[v0.28.0](https://hub.docker.com/layers/prom/blackbox-exporter/v0.28.0)                     |
-|Blockfrost           |Binary        |[v6.4.0](https://github.com/blockfrost/blockfrost-backend-ryo/releases/tag/v6.4.0)          |
-|Cardano CLI          |Binary/Source |[10.15.1.0](https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-10.15.1.0) |
-|Cardano DB Sync      |Binary        |[13.6.0.4](https://github.com/IntersectMBO/cardano-db-sync/releases/tag/13.6.0.4)           |
-|Cardano Node         |Binary/Source |[10.6.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.4), [10.7.1](https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1), [11.0.1](https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1) |
-|Cardano TX Generator |Source        |[10.6.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.4)                  |
+|Blockfrost           |Binary        |[v6.4.3](https://github.com/blockfrost/blockfrost-backend-ryo/releases/tag/v6.4.3)          |
+|Cardano CLI          |Binary/Source |[11.0.0.0](https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-11.0.0.0)   |
+|Cardano DB Sync      |Binary        |[13.7.1.0](https://github.com/IntersectMBO/cardano-db-sync/releases/tag/13.7.1.0)           |
+|Cardano Node         |Binary/Source |[11.0.1](https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1), [10.7.1](https://github.com/IntersectMBO/cardano-node/releases/tag/10.7.1), [10.6.4](https://github.com/IntersectMBO/cardano-node/releases/tag/10.6.4) |
+|Cardano TX Generator |Source        |[11.0.1](https://github.com/IntersectMBO/cardano-node/releases/tag/11.0.1)                  |
 |CoreDNS              |Image         |[1.14.3](https://hub.docker.com/layers/coredns/coredns/1.14.3)                              |
-|Debian               |Image         |[stable-20260421-slim](https://hub.docker.com/layers/library/debian/stable-slim)            |
-|Grafana              |Image         |[13.0.1](https://hub.docker.com/layers/grafana/grafana/13.0.1)                              |
-|Jaeger               |Image         |[2.17.0](https://hub.docker.com/layers/jaegertracing/jaeger/2.17.0)                         |
-|Loki                 |Image         |[3.7.1](https://hub.docker.com/layers/grafana/loki/3.7.1)                                   |
+|Debian               |Image         |[stable-20260518-slim](https://hub.docker.com/layers/library/debian/stable-slim)            |
+|Grafana              |Image         |[13.0.2](https://hub.docker.com/layers/grafana/grafana/13.0.2)                              |
+|Jaeger               |Image         |[2.18.0](https://hub.docker.com/layers/jaegertracing/jaeger/2.18.0)                         |
+|Loki                 |Image         |[3.7.2](https://hub.docker.com/layers/grafana/loki/3.7.2)                                   |
 |Node Exporter        |Binary        |[v1.11.1](https://github.com/prometheus/node_exporter/releases/tag/v1.11.1)                 |
-|PostgreSQL           |Package       |[17.9](https://www.postgresql.org/docs/release/17.9)                                        |
+|PostgreSQL           |Package       |[17.10](https://www.postgresql.org/docs/release/17.10)                                      |
 |Process Exporter     |Binary        |[v0.8.7](https://github.com/ncabatoff/process-exporter/releases/tag/v0.8.7)                 |
-|Prometheus           |Image         |[v3.11.2](https://hub.docker.com/layers/prom/prometheus/v3.11.2)                            |
-|Yaci Store           |Image         |[v2.0.0](https://github.com/bloxbean/yaci-store/releases/tag/v2.0.0)                        |
-|uv                   |Binary        |[0.11.7](https://github.com/astral-sh/uv/releases/tag/0.11.7)                               |
+|Prometheus           |Image         |[v3.12.0](https://hub.docker.com/layers/prom/prometheus/v3.12.0)                            |
+|Yaci Store           |Image         |[v2.0.1](https://github.com/bloxbean/yaci-store/releases/tag/v2.0.1)                        |
+|uv                   |Binary        |[0.11.18](https://github.com/astral-sh/uv/releases/tag/0.11.18)                             |
 |yq                   |Binary        |[v4.53.2](https://github.com/mikefarah/yq/releases/tag/v4.53.2)                             |

--- a/amaru/Dockerfile.source
+++ b/amaru/Dockerfile.source
@@ -42,7 +42,7 @@ RUN cabal update && \
 RUN strip --strip-unneeded /usr/local/bin/db-server
 
 # Install rustup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh -s -- -y
 
 
 RUN ln -s /root/.cargo/bin/cargo /usr/local/bin/cargo && \
@@ -71,12 +71,12 @@ RUN /usr/local/src/amaru/target/release/amaru --help
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/node_exporter
 
 # Download node_exporter archive
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
 
 # Download node_exporter checksum
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/sha256sums.txt \
         --output /usr/local/src/node_exporter/sha256sums.txt
 
@@ -98,12 +98,12 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
 # Download process_exporter archive
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
 # Download process_exporter checksum
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -123,7 +123,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 # Set time zone
 ENV TZ="UTC"

--- a/blockfrost/Dockerfile
+++ b/blockfrost/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
-ARG BLOCKFROST_BACKEND_RYO="${BLOCKFROST_BACKEND_RYO:-6.4.0}"
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
+ARG BLOCKFROST_BACKEND_RYO="${BLOCKFROST_BACKEND_RYO:-6.4.3}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-11.0.0.0}"
 ARG NODEJS_MAJOR_VERSION="${NODEJS_MAJOR_VERSION:-24}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
@@ -48,11 +48,11 @@ RUN yarn --frozen-lockfile && \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-cli
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt
 
@@ -69,11 +69,11 @@ RUN ln -s /usr/local/src/cardano-cli/cardano-cli-x86_64-linux /usr/local/bin/car
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -88,7 +88,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/cardano-db-sync/Dockerfile.binary
+++ b/cardano-db-sync/Dockerfile.binary
@@ -1,7 +1,7 @@
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
-ARG CARDANO_DB_SYNC_VERSION="${CARDANO_DB_SYNC_VERSION:-13.6.0.4}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-11.0.0.0}"
+ARG CARDANO_DB_SYNC_VERSION="${CARDANO_DB_SYNC_VERSION:-13.7.1.0}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 ENV TZ="UTC"
@@ -21,15 +21,15 @@ RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/car
     install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-db-sync/git && \
     install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-db-sync/tar
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-db-sync/releases/download/${CARDANO_DB_SYNC_VERSION}/cardano-db-sync-${CARDANO_DB_SYNC_VERSION}-linux.tar.gz \
         --output /usr/local/src/cardano-db-sync/cardano-db-sync-${CARDANO_DB_SYNC_VERSION}-linux.tar.gz
 
 RUN tar --extract --gzip --file=/usr/local/src/cardano-db-sync/cardano-db-sync-${CARDANO_DB_SYNC_VERSION}-linux.tar.gz --directory=/usr/local/src/cardano-db-sync/tar
 
-RUN chmod 0755 /usr/local/src/cardano-db-sync/tar/cardano-db-sync
+RUN chmod 0755 /usr/local/src/cardano-db-sync/tar/bin/cardano-db-sync
 
-RUN ln -s /usr/local/src/cardano-db-sync/tar/cardano-db-sync /usr/local/bin/cardano-db-sync
+RUN ln -s /usr/local/src/cardano-db-sync/tar/bin/cardano-db-sync /usr/local/bin/cardano-db-sync
 
 WORKDIR /usr/local/src/cardano-db-sync/git
 RUN git clone --depth=1 --branch ${CARDANO_DB_SYNC_VERSION} https://github.com/IntersectMBO/cardano-db-sync.git
@@ -38,11 +38,11 @@ RUN git clone --depth=1 --branch ${CARDANO_DB_SYNC_VERSION} https://github.com/I
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-cli
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt
 
@@ -59,11 +59,11 @@ RUN ln -s /usr/local/src/cardano-cli/cardano-cli-x86_64-linux /usr/local/bin/car
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -78,7 +78,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket" \
     PGPASSFILE="/opt/cardano-db-sync/config/pgpass"

--- a/cardano-node/Dockerfile.binary
+++ b/cardano-node/Dockerfile.binary
@@ -4,7 +4,7 @@ ARG TESTNET_BUILDER_IMAGE=scratch
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
 ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-10.5.4}"
 ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
@@ -25,7 +25,7 @@ RUN apt update && \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-node
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VERSION}/cardano-node-${CARDANO_NODE_VERSION}-linux-amd64.tar.gz \
         --output /usr/local/src/cardano-node/cardano-node-${CARDANO_NODE_VERSION}-linux-amd64.tar.gz
 
@@ -43,11 +43,11 @@ RUN ln -s /usr/local/src/cardano-node/${CARDANO_NODE_VERSION}/bin/cardano-cli /u
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/node_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/sha256sums.txt \
         --output /usr/local/src/node_exporter/sha256sums.txt
 
@@ -64,11 +64,11 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -85,7 +85,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/cardano-node/Dockerfile.source
+++ b/cardano-node/Dockerfile.source
@@ -17,11 +17,11 @@ ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/node_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/sha256sums.txt \
         --output /usr/local/src/node_exporter/sha256sums.txt
 
@@ -36,7 +36,7 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 # cardano-cli
 
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.15.1.0}"
+ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-11.0.0.0}"
 
 WORKDIR /usr/local/src
 RUN git clone --depth 1 --branch master https://github.com/IntersectMBO/cardano-cli.git
@@ -111,11 +111,11 @@ RUN cabal install exe:tx-generator --disable-test --install-method=copy \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -132,7 +132,7 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV CARDANO_NODE_SOCKET_PATH="/opt/cardano-node/data/db/node.socket"
 

--- a/changelog.d/20260603_085359_l_version_update_20260603.md
+++ b/changelog.d/20260603_085359_l_version_update_20260603.md
@@ -1,0 +1,14 @@
+### Updated
+
+- Update Blockfrost from 6.4.0 to 6.4.3
+- Update Cardano CLI from 10.15.1.0 to 11.0.0.0
+- Update Cardano DB Sync from 13.6.0.4 to 13.7.1.0
+- Update Cardano TX Generator from 10.6.4 to 11.0.1
+- Update Debian from stable-20260421-slim to stable-20260518-slim
+- Update Grafana from 13.0.1 to 13.0.2
+- Update Jaeger from 2.17.0 to 2.18.0
+- Update Loki from 3.7.1 to 3.7.2
+- Update PostgreSQL from 17.9 to 17.10
+- Update Prometheus from 3.11.2 to 3.12.0
+- Update Yaci Store from 2.0.0 to 2.0.1
+- Update uv from 0.11.7 to 0.11.18

--- a/db-synthesizer/Dockerfile
+++ b/db-synthesizer/Dockerfile
@@ -37,7 +37,7 @@ RUN strip --strip-unneeded /usr/local/bin/db-synthesizer
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
 ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 
@@ -17,11 +17,11 @@ RUN apt update && \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/node_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/sha256sums.txt \
         --output /usr/local/src/node_exporter/sha256sums.txt
 
@@ -36,7 +36,7 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \

--- a/haskell-builder/Dockerfile
+++ b/haskell-builder/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------------------------------------
 #  Shared build environment for Cardano binaries
 # -------------------------------------------------
-ARG BASE_IMAGE=docker.io/debian:stable-20260421-slim
+ARG BASE_IMAGE=docker.io/debian:stable-20260518-slim
 FROM ${BASE_IMAGE} AS haskell-builder
 
 # ── Common ARGs (keep the defaults from the originals) ──

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
@@ -61,11 +61,11 @@ RUN install --directory --owner=root --group=root --mode=0755 /var/local/postgre
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
-ARG CARDANO_CLI_VERSION="10.15.1.0"
+ARG CARDANO_CLI_VERSION="11.0.0.0"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
 
 ENV TZ="UTC"
@@ -16,11 +16,11 @@ RUN apt update && \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-cli
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-x86_64-linux.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-cli/releases/download/cardano-cli-${CARDANO_CLI_VERSION}/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt \
         --output /usr/local/src/cardano-cli/cardano-cli-${CARDANO_CLI_VERSION}-sha256sums.txt
 
@@ -37,11 +37,11 @@ RUN ln -s /usr/local/src/cardano-cli/cardano-cli-x86_64-linux /usr/local/bin/car
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -56,7 +56,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ARG GRAPHNODES
 

--- a/testnet-generation-tool/Dockerfile
+++ b/testnet-generation-tool/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/debian:stable-20260421-slim AS testnet_builder
+FROM docker.io/debian:stable-20260518-slim AS testnet_builder
 
-ARG UV_VERSION="${UV_VERSION:-0.11.7}"
+ARG UV_VERSION="${UV_VERSION:-0.11.18}"
 ARG TESTNET_GENERATION_TOOL_VERSION="v0.2.0"
 
 ENV TZ="UTC"
@@ -17,11 +17,11 @@ RUN apt update && \
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/uv
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz \
         --output /usr/local/src/uv/uv-x86_64-unknown-linux-gnu.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz.sha256 \
         --output /usr/local/src/uv/uv-x86_64-unknown-linux-gnu.tar.gz.sha256
 

--- a/testnets/global_network/docker-compose.yaml
+++ b/testnets/global_network/docker-compose.yaml
@@ -919,7 +919,7 @@ services:
     profiles: [build, optional, mgmt]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -968,7 +968,7 @@ services:
     profiles: [build, core, mgmt]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -986,7 +986,7 @@ services:
     profiles: [build, core, mgmt]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/global_network_2c/docker-compose.yaml
+++ b/testnets/global_network_2c/docker-compose.yaml
@@ -723,7 +723,7 @@ services:
 
   prometheus:
     <<: *mgmt_cpu
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -770,7 +770,7 @@ services:
 
   loki:
     <<: *mgmt_cpu
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -789,7 +789,7 @@ services:
 
   grafana:
     <<: *mgmt_cpu
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/global_network_mixed_nodes/docker-compose.yaml
+++ b/testnets/global_network_mixed_nodes/docker-compose.yaml
@@ -977,7 +977,7 @@ services:
     profiles: [build, optional, mgmt]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -1026,7 +1026,7 @@ services:
     profiles: [build, core, mgmt]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -1044,7 +1044,7 @@ services:
     profiles: [build, core, mgmt]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped
@@ -1065,7 +1065,7 @@ services:
     profiles: [build, core, mgmt]
 
   jaeger:
-    image: jaegertracing/jaeger:2.17.0
+    image: jaegertracing/jaeger:2.18.0
     container_name: jaeger
     hostname: jaeger.example
     restart: unless-stopped

--- a/testnets/simple_mixed_consensus/docker-compose.yaml
+++ b/testnets/simple_mixed_consensus/docker-compose.yaml
@@ -302,7 +302,7 @@ services:
     profiles: [optional]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -329,7 +329,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -341,7 +341,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/simple_mixed_nodes_source/docker-compose.yaml
+++ b/testnets/simple_mixed_nodes_source/docker-compose.yaml
@@ -235,7 +235,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -262,7 +262,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -274,7 +274,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped
@@ -289,7 +289,7 @@ services:
     profiles: [build, core]
 
   jaeger:
-    image: jaegertracing/jaeger:2.17.0
+    image: jaegertracing/jaeger:2.18.0
     container_name: jaeger
     hostname: jaeger.example
     restart: unless-stopped

--- a/testnets/simple_network_binary/docker-compose.yaml
+++ b/testnets/simple_network_binary/docker-compose.yaml
@@ -165,7 +165,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -192,7 +192,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -204,7 +204,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/simple_network_source/docker-compose.yaml
+++ b/testnets/simple_network_source/docker-compose.yaml
@@ -183,7 +183,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -210,7 +210,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -222,7 +222,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/testnets/single_pool_binary/docker-compose.yaml
+++ b/testnets/single_pool_binary/docker-compose.yaml
@@ -140,7 +140,7 @@ services:
     profiles: [build, optional]
 
   prometheus:
-    image: prom/prometheus:v3.11.2
+    image: prom/prometheus:v3.12.0
     container_name: prometheus
     hostname: prometheus.example
     restart: unless-stopped
@@ -167,7 +167,7 @@ services:
     profiles: [build, core]
 
   loki:
-    image: grafana/loki:3.7.1
+    image: grafana/loki:3.7.2
     container_name: loki
     hostname: loki.example
     restart: unless-stopped
@@ -179,7 +179,7 @@ services:
     profiles: [build, core]
 
   grafana:
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.2
     container_name: grafana
     hostname: grafana.example
     restart: unless-stopped

--- a/yaci-store/Dockerfile.binary
+++ b/yaci-store/Dockerfile.binary
@@ -6,12 +6,12 @@ FROM ${TESTNET_BUILDER_IMAGE} AS testnet_builder
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS build
+FROM docker.io/debian:stable-20260518-slim AS build
 
 ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-11.0.1}"
 ARG NODE_EXPORTER_VERSION="${NODE_EXPORTER_VERSION:-1.11.1}"
 ARG PROCESS_EXPORTER_VERSION="${PROCESS_EXPORTER_VERSION:-0.8.7}"
-ARG YACI_STORE_VERSION="${YACI_STORE_VERSION:-2.0.0}"
+ARG YACI_STORE_VERSION="${YACI_STORE_VERSION:-2.0.1}"
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
@@ -26,7 +26,7 @@ RUN apt update && \
 # cardano-cli
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/cardano-node
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/IntersectMBO/cardano-node/releases/download/${CARDANO_NODE_VERSION}/cardano-node-${CARDANO_NODE_VERSION}-linux-amd64.tar.gz \
         --output /usr/local/src/cardano-node/cardano-node-${CARDANO_NODE_VERSION}-linux-amd64.tar.gz
 
@@ -42,7 +42,7 @@ RUN ln -s /usr/local/src/cardano-node/${CARDANO_NODE_VERSION}/bin/cardano-cli /u
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/yaci-store
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/bloxbean/yaci-store/releases/download/rel-native-${YACI_STORE_VERSION}/yaci-store-${YACI_STORE_VERSION}-linux-x64-all.zip \
         --output /usr/local/src/yaci-store/yaci-store-${YACI_STORE_VERSION}-linux-x64-all.zip
 
@@ -54,11 +54,11 @@ RUN ln -s /usr/local/src/yaci-store/yaci-store-${YACI_STORE_VERSION}/yaci-store 
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/node_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/prometheus/node_exporter/releases/download/v${NODE_EXPORTER_VERSION}/sha256sums.txt \
         --output /usr/local/src/node_exporter/sha256sums.txt
 
@@ -75,11 +75,11 @@ RUN ln -s /usr/local/src/node_exporter/node_exporter-${NODE_EXPORTER_VERSION}.li
 
 RUN install --directory --owner=root --group=root --mode=0755 /usr/local/src/process_exporter
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz \
         --output /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VERSION}.linux-amd64.tar.gz
 
-RUN curl --proto '=https' --tlsv1.2 \
+RUN curl --proto '=https' --tlsv1.3 \
         --location https://github.com/ncabatoff/process-exporter/releases/download/v${PROCESS_EXPORTER_VERSION}/checksums.txt \
         --output /usr/local/src/process_exporter/checksums.txt
 
@@ -94,7 +94,7 @@ RUN ln -s /usr/local/src/process_exporter/process-exporter-${PROCESS_EXPORTER_VE
 
 #---------------------------------------------------------------------
 
-FROM docker.io/debian:stable-20260421-slim AS main
+FROM docker.io/debian:stable-20260518-slim AS main
 
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \


### PR DESCRIPTION
Update Blockfrost from 6.4.0 to 6.4.3
Update Cardano CLI from 10.15.1.0 to 11.0.0.0
Update Cardano DB Sync from 13.6.0.4 to 13.7.1.0
Update Cardano TX Generator from 10.6.4 to 11.0.1
Update Debian from stable-20260421-slim to stable-20260518-slim Update Grafana from 13.0.1 to 13.0.2
Update Jaeger from 2.17.0 to 2.18.0
Update Loki from 3.7.1 to 3.7.2
Update PostgreSQL from 17.9 to 17.10
Update Prometheus from 3.11.2 to 3.12.0
Update Yaci Store from 2.0.0 to 2.0.1
Update uv from 0.11.7 to 0.11.18