### PR TITLE
replace UTXOHD with LEDGER_DB_BACKEND

### DIFF
--- a/cardano-node/cmd.sh
+++ b/cardano-node/cmd.sh
@@ -14,6 +14,7 @@ DB_SIDECAR_PASSWORD="${DB_SIDECAR_PASSWORD:-sidecar}"
 DB_SIDECAR_USERNAME="${DB_SIDECAR_USERNAME:-sidecar}"
 EGRESS_POLL_INTERVAL="${EGRESS_POLL_INTERVAL:-0}"
 EXTRA_LOCALROOTS="${EXTRA_LOCALROOTS:-}"
+LEDGER_DB_BACKEND="${LEDGER_DB_BACKEND:-V2InMemory}"
 NO_INTERPOOL_LOCALROOTS="${NO_INTERPOOL_LOCALROOTS:-false}"
 OUROBOROS_GENESIS="${OUROBOROS_GENESIS:-false}"
 PEER_SHARING="${PEER_SHARING:-true}"
@@ -24,7 +25,6 @@ SHUTDOWN_ON_BLOCK="${SHUTDOWN_ON_BLOCK:-}"
 SYSTEM_START="${SYSTEM_START:-$(date -d "@$(( ( $(date +%s) / 180 ) * 180 ))" +%Y-%m-%dT%H:%M:00Z)}"
 TYPE="${TYPE:-bprelay}"
 USE_LEDGER_AFTER_SLOT="${USE_LEDGER_AFTER_SLOT:-0}"
-UTXOHD="${UTXOHD:-false}"
 TX_SUBMISSION_LOGIC_VERSION="${TX_SUBMISSION_LOGIC_VERSION:-1}"
 
 # Configuration files
@@ -86,11 +86,24 @@ config_config_json() {
         jq ".ConsensusMode = \"PraosMode\"" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
     fi
 
-    if [ "${UTXOHD,,}" = "true" ]; then
-        jq ".LedgerDB = {\"Backend\": \"V1LMDB\", \"LiveTablesPath\": \"${DATABASE_PATH}/lmdb\"  }" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
-    else
-        jq ".LedgerDB = {\"Backend\": \"V2InMemory\" }" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
-    fi
+    local ledger_db_json
+    case "${LEDGER_DB_BACKEND}" in
+        V1LMDB)
+            ledger_db_json="{\"Backend\": \"V1LMDB\", \"LiveTablesPath\": \"${DATABASE_PATH}/lmdb\"}"
+            ;;
+        V2InMemory)
+            ledger_db_json="{\"Backend\": \"V2InMemory\"}"
+            ;;
+        V2LSM)
+            ledger_db_json="{\"Backend\": \"V2LSM\", \"LSMDatabasePath\": \"${DATABASE_PATH}/lsm\"}"
+            ;;
+        *)
+            echo "Invalid LEDGER_DB_BACKEND: ${LEDGER_DB_BACKEND}" >&2
+            echo "Expected one of: V1LMDB, V2InMemory, V2LSM" >&2
+            exit 1
+            ;;
+    esac
+    jq ".LedgerDB = ${ledger_db_json}" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
 
     jq ".EgressPollInterval = ${EGRESS_POLL_INTERVAL}" "${CONFIG_JSON}" | write_file "${CONFIG_JSON}"
 

--- a/cardano-node/seccomp-io_uring.json
+++ b/cardano-node/seccomp-io_uring.json
@@ -1,0 +1,848 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 1,
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_RISCV64",
+      "subArchitectures": null
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "_llseek",
+        "_newselect",
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "cachestat",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_adjtime",
+        "clock_adjtime64",
+        "clock_getres",
+        "clock_getres_time64",
+        "clock_gettime",
+        "clock_gettime64",
+        "clock_nanosleep",
+        "clock_nanosleep_time64",
+        "close",
+        "close_range",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_pwait2",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "faccessat2",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchmodat2",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futex_requeue",
+        "futex_time64",
+        "futex_wait",
+        "futex_waitv",
+        "futex_wake",
+        "futimesat",
+        "get_robust_list",
+        "get_thread_area",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "getxattrat",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "io_destroy",
+        "io_getevents",
+        "io_pgetevents",
+        "io_pgetevents_time64",
+        "io_setup",
+        "io_submit",
+        "io_uring_enter",
+        "io_uring_register",
+        "io_uring_setup",
+        "ioctl",
+        "ioprio_get",
+        "ioprio_set",
+        "ipc",
+        "kill",
+        "landlock_add_rule",
+        "landlock_create_ruleset",
+        "landlock_restrict_self",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listmount",
+        "listxattr",
+        "listxattrat",
+        "llistxattr",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "map_shadow_stack",
+        "membarrier",
+        "memfd_create",
+        "memfd_secret",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedreceive_time64",
+        "mq_timedsend",
+        "mq_timedsend_time64",
+        "mq_unlink",
+        "mremap",
+        "mseal",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "name_to_handle_at",
+        "nanosleep",
+        "newfstatat",
+        "open",
+        "openat",
+        "openat2",
+        "pause",
+        "pidfd_open",
+        "pidfd_send_signal",
+        "pipe",
+        "pipe2",
+        "pkey_alloc",
+        "pkey_free",
+        "pkey_mprotect",
+        "poll",
+        "ppoll",
+        "ppoll_time64",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "process_mrelease",
+        "pselect6",
+        "pselect6_time64",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmmsg_time64",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "removexattrat",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "riscv_hwprobe",
+        "rmdir",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_sigtimedwait_time64",
+        "rt_tgsigqueueinfo",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_rr_get_interval_time64",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "semtimedop_time64",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "set_robust_list",
+        "set_thread_area",
+        "set_tid_address",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "setsid",
+        "setsockopt",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "setxattrat",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigprocmask",
+        "sigreturn",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statmount",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_gettime64",
+        "timer_settime",
+        "timer_settime64",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_gettime64",
+        "timerfd_settime",
+        "timerfd_settime64",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "uretprobe",
+        "utime",
+        "utimensat",
+        "utimensat_time64",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW"
+    },
+    {
+      "names": [
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "minKernel": "4.8"
+      }
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 40,
+          "op": "SCMP_CMP_NE"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "names": [
+        "sync_file_range2",
+        "swapcontext"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "arch_prctl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      }
+    },
+    {
+      "names": [
+        "modify_ldt"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      }
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "riscv_flush_icache"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "arches": [
+          "riscv64"
+        ]
+      }
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf",
+        "clone",
+        "clone3",
+        "fanotify_init",
+        "fsconfig",
+        "fsmount",
+        "fsopen",
+        "fspick",
+        "lookup_dcookie",
+        "lsm_get_self_attr",
+        "lsm_list_modules",
+        "lsm_set_self_attr",
+        "mount",
+        "mount_setattr",
+        "move_mount",
+        "open_tree",
+        "perf_event_open",
+        "quotactl",
+        "quotactl_fd",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ],
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "value": 2114060288,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone3"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 38,
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "reboot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_BOOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "chroot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "delete_module",
+        "init_module",
+        "finit_module"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      }
+    },
+    {
+      "names": [
+        "kcmp",
+        "pidfd_getfd",
+        "process_madvise",
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "iopl",
+        "ioperm"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      }
+    },
+    {
+      "names": [
+        "settimeofday",
+        "stime",
+        "clock_settime",
+        "clock_settime64"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      }
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "get_mempolicy",
+        "mbind",
+        "set_mempolicy",
+        "set_mempolicy_home_node"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYS_NICE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "syslog"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_SYSLOG"
+        ]
+      }
+    },
+    {
+      "names": [
+        "bpf"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_BPF"
+        ]
+      }
+    },
+    {
+      "names": [
+        "perf_event_open"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "includes": {
+        "caps": [
+          "CAP_PERFMON"
+        ]
+      }
+    }
+  ]
+}

--- a/changelog.d/20260806_132349_karl.fb.knutsson_ledger_db_backend.md
+++ b/changelog.d/20260806_132349_karl.fb.knutsson_ledger_db_backend.md
@@ -1,0 +1,4 @@
+### Changed
+
+- replace UTXOHD with LEDGER_DB_BACKEND, can be either V1LMDB, V2LSM or V2InMemory (default).
+

--- a/testnets/global_network/docker-compose.yaml
+++ b/testnets/global_network/docker-compose.yaml
@@ -4,6 +4,11 @@ x-base: &base
   restart: unless-stopped
   cap_add:
     - NET_ADMIN
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -824,7 +829,7 @@ services:
     environment:
       POOL_ID: "1"
       TYPE: "client"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
       SYSTEM_START: ${SYSTEM_START:-}
     networks:
       net_eu:
@@ -845,7 +850,7 @@ services:
       TPS: "1"
       TX_GEN_MODE: "plain"
       #TX_GEN_MODE: "plutus"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
       SYSTEM_START: ${SYSTEM_START:-}
     networks:
       net_na:

--- a/testnets/global_network_2c/docker-compose.yaml
+++ b/testnets/global_network_2c/docker-compose.yaml
@@ -20,6 +20,11 @@ x-base: &base
   restart: unless-stopped
   cap_add:
     - NET_ADMIN
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -70,7 +75,6 @@ x-node-env-common: &node_env_common
   SHUTDOWN_ON_BLOCK: ${SHUTDOWN_ON_BLOCK:-}
   SHUTDOWN_ON_SLOT: ${SHUTDOWN_ON_SLOT:-}
   PEER_SHARING: "true"
-  UTXOHD: "false"
   OUROBOROS_GENESIS: "false"
   EGRESS_POLL_INTERVAL: ${EGRESS_POLL_INTERVAL:-0.001}
 
@@ -646,7 +650,7 @@ services:
       POOL_ID: "1"
       TYPE: client
       REGION: EU
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
     networks:
       net_eu:
         ipv4_address: 172.16.3.4
@@ -667,7 +671,7 @@ services:
       TPS: ${TPS:-12}
       TX_GEN_MODE: ${TX_GEN_MODE:-plain}
       TX_GENERATOR_TARGETS: "172.16.1.104,172.16.3.104,172.16.1.114,172.16.3.114"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
     networks:
       net_na:
         ipv4_address: 172.16.1.12

--- a/testnets/global_network_mixed_nodes/docker-compose.yaml
+++ b/testnets/global_network_mixed_nodes/docker-compose.yaml
@@ -4,6 +4,11 @@ x-base: &base
   restart: unless-stopped
   cap_add:
     - NET_ADMIN
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -881,7 +886,6 @@ services:
     environment:
       POOL_ID: "1"
       TYPE: "client"
-      UTXOHD: "false"
       SYSTEM_START: ${SYSTEM_START:-}
       EXTRA_LOCALROOTS: "a1.example:3001,a2.example:3001"
     networks:
@@ -903,7 +907,6 @@ services:
       TPS: "1"
       TX_GEN_MODE: "plain"
       #TX_GEN_MODE: "plutus"
-      UTXOHD: "false"
       SYSTEM_START: ${SYSTEM_START:-}
     networks:
       net_na:

--- a/testnets/simple_mixed_consensus/docker-compose.yaml
+++ b/testnets/simple_mixed_consensus/docker-compose.yaml
@@ -2,6 +2,11 @@
 
 x-base: &base
   restart: unless-stopped
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -40,7 +45,7 @@ services:
       POOL_ID: "1"
       PEER_SHARING: "false"
       OUROBOROS_GENESIS: "true"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V2LSM"
     profiles: [build, core, pools]
 
   p2:
@@ -81,7 +86,7 @@ services:
       <<: *env
       POOL_ID: "4"
       OUROBOROS_GENESIS: "true"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V2LSM"
     profiles: [build, core, pools]
 
   p5:
@@ -145,7 +150,7 @@ services:
     environment:
       <<: *env
       POOL_ID: "9"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
     profiles: [build, core, pools]
 
   p10:
@@ -240,7 +245,7 @@ services:
       POOL_ID: "1"
       TYPE: "txg"
       TPS: "1"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
       SYSTEM_START: ${SYSTEM_START:-}
     profiles: [build, optional]
 

--- a/testnets/simple_mixed_nodes_source/docker-compose.yaml
+++ b/testnets/simple_mixed_nodes_source/docker-compose.yaml
@@ -2,6 +2,11 @@
 
 x-base: &base
   restart: unless-stopped
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -173,7 +178,6 @@ services:
       TYPE: "txg"
       TPS: "1"
       TX_GEN_MODE: "plain"
-      UTXOHD: "false"
       SYSTEM_START: ${SYSTEM_START:-}
     profiles: [build, optional]
 

--- a/testnets/simple_network_source/docker-compose.yaml
+++ b/testnets/simple_network_source/docker-compose.yaml
@@ -2,6 +2,11 @@
 
 x-base: &base
   restart: unless-stopped
+  # Allows io_uring, which Docker's default seccomp profile blocks. Needed for
+  # LEDGER_DB_BACKEND=V2LSM (the blockio-uring-based LSM ledger backend); a
+  # no-op for nodes using V1LMDB/V2InMemory. See cardano-node/seccomp-io_uring.json.
+  security_opt:
+    - "seccomp=../../cardano-node/seccomp-io_uring.json"
   logging:
     driver: "loki"
     options:
@@ -121,7 +126,7 @@ services:
       POOL_ID: "1"
       TYPE: "txg"
       TPS: "1"
-      UTXOHD: "true"
+      LEDGER_DB_BACKEND: "V1LMDB"
       SYSTEM_START: ${SYSTEM_START:-}
     profiles: [build, optional]
 


### PR DESCRIPTION
Replace UTXOHD (bool) with LEDGER_DB_BACKEND. LEDGER_DB_BACKEND defaults to V2InMemory.

V2LSM depends on io_uring which is why cardano-node's now use a special seccomp file.